### PR TITLE
Add support for CircleCI (temporarily disabled)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,9 @@
+general:
+  branches:
+    ignore:
+      - /.*/
+
+test:
+  override:
+    # In case the skip fails for some reason, do a fast finish.
+    - exit 0


### PR DESCRIPTION
So, I have enabled CircleCI to build on this repo. However, we don't have anything for it to build ATM. As CircleCI tries to be clever and build one's project as it sees fit, we need to explicitly tell it not to build. That is what this `circle.yml` file does. It tells it to skip builds on any branch.

However, we have seen in some rare cases ( https://github.com/conda-forge/conda-smithy/pull/242#issue-167200826 ) that it may miss this ignore statement. Thus, we have added a no-op passing build step to ensure that it doesn't do anything.
